### PR TITLE
Update SplitJoin.xml

### DIFF
--- a/Utilities/SplitJoin.xml
+++ b/Utilities/SplitJoin.xml
@@ -11,7 +11,7 @@
 			<setvar name="setVar" varname="ExplodedInput1">"${phonenumber}".split("").join(" ");</setvar>
 			<play name="confirm" type="tts" voice="female2">You entered a phone number of.  ${ExplodedInput1}.</play>
 			<menu name="Menu_confirm" maxDigits="1" timeout="3500">
-				<play name="yesorno" type="tts" voice="female2">Is this correct?  Press 1 for yes.  Press any other key to enter a new number.</play>
+				<play name="yesorno" type="tts" voice="female2">Is this correct?  Press 1 for yes.  Press any other key to enter a new phone number.</play>
 				<keypress name="keypress_yes" pressed="1">
 					<goto name="goto_play_callnow">NextPlay</goto>
 				</keypress>


### PR DESCRIPTION
'.split()' breaks apart the string at the spot described in the argument. For example, '.split("")' says to break apart the string between every element; '.split("|")' says to break it apart every time it reaches the "pipe" character ( | ); '.split(",")' says to break it apart every time it reaches a comma.

'.join()' puts the string back together with whatever character is indicated by the argument inserted between the previously split elements. For example, '.join("|")' puts the string back together with the "pipe" as a delimiter.

'.join(" ")' puts the string back with a space between the elements. This is used to "explode" a number for correct text-to-speech playback.

The semicolon ';' is used to end a Java command.

For example, to "explode" a number for correct TTS playback, we would need to split each element (number) in the string and insert a space between them. Assuming our "number" is the variable 'acctNum', our tag would look like this:

<setvar name="setvar_explNum" varname="explAcctNum">${acctNum}.split("").join(" ");</setvar>

Suppose we sent an account ID using a get tag, and got back a variable ('myResult') that contained three elements — the user name, account balance, and due date — separated by a 'pipe' ( | ) delimiter. We could take the results of the Get Tag ('myResult') and split it into the three elements at the pipe delimiter, and place each element into its own variable:

<setvar name="setvar_user" varname="userName">${myResult}.split("|")[0];</setvar>
<setvar name="setvar_balance" varname="acctBal">${myResult}.split("|")[1];</setvar>
<setvar name="setvar_dueDate" varname="dueDate">${myResult}.split("|")[2];</setvar>
